### PR TITLE
Update IoT docs to .NET 10 and latest packages

### DIFF
--- a/docs/iot/debugging.md
+++ b/docs/iot/debugging.md
@@ -2,7 +2,7 @@
 title: Debug .NET apps on ARM single-board computers
 description: Learn how to debug .NET apps on ARM single-board computers (SBCs) such as Raspberry Pi.
 author: camsoper
-ms.date: 07/31/2024
+ms.date: 03/07/2026
 ms.topic: how-to
 zone_pivot_groups: ide-set-one
 ---
@@ -16,13 +16,10 @@ For these reasons, it's strongly recommended that you develop your app on a deve
 - A 64-bit OS with a desktop environment, such as Raspberry Pi OS (64-bit).
 - [Visual Studio Code](https://code.visualstudio.com/docs/setup/raspberry-pi) with the [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp).
   - Disable the [hardware acceleration](https://code.visualstudio.com/docs/setup/raspberry-pi#_workaround-for-poor-performance).
-- .NET SDK 6.0 or later.
+- .NET SDK 10 or later.
   - Install using the *dotnet-install* script [as in a framework-dependent deployment](deployment.md#deploying-a-framework-dependent-app). Be sure to add a `DOTNET_ROOT` environment variable and add the *.dotnet* directory to `$PATH`.
 
 The rest of this article describes how to debug .NET apps on single-board computers remotely from a development computer.
-
-> [!IMPORTANT]
-> As of this writing, remotely debugging .NET 7 apps in `linux-arm` environments is unreliable and may cause the process to exit prematurely. This issue is under investigation. .NET 6 apps that target `linux-arm` and .NET 7 apps that target `linux-arm64` are unaffected.
 
 ::: zone pivot="vscode"
 

--- a/docs/iot/deployment.md
+++ b/docs/iot/deployment.md
@@ -2,7 +2,7 @@
 title: Deploy .NET apps to ARM single-board computers
 description: Learn how to deploy .NET apps to ARM single-board computers (SBCs) such as Raspberry Pi.
 author: camsoper
-ms.date: 07/31/2024
+ms.date: 03/07/2026
 ms.topic: how-to
 ---
 
@@ -24,11 +24,11 @@ To deploy your app as a framework-dependent app, complete the following steps:
     1. Run the following command to install .NET:
 
         ```bash
-        curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel STS
+        curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel LTS
         ```
 
         > [!NOTE]
-        > This command installs the latest version. If you need a specific version, replace the `--channel STS` parameter with `--version <VERSION>`, where `<VERSION>` is the specific build version, for example `8.0.404`. For a list of versions, see [.NET SDKs for Visual Studio](https://dotnet.microsoft.com/download/visual-studio-sdks). To determine the full build number, refer to the **Visual Studio 2026 SDK** column.
+        > This command installs the latest LTS version. If you need a specific version, replace the `--channel LTS` parameter with `--version <VERSION>`, where `<VERSION>` is the specific build version, for example `10.0.103`. For a list of versions, see [.NET SDKs for Visual Studio](https://dotnet.microsoft.com/download/visual-studio-sdks). To determine the full build number, refer to the **Visual Studio 2026 SDK** column.
 
     1. To simplify path resolution, add a `DOTNET_ROOT` environment variable and add the *.dotnet* directory to `$PATH` with the following commands:
 

--- a/docs/iot/includes/tutorial-add-gpio-package.md
+++ b/docs/iot/includes/tutorial-add-gpio-package.md
@@ -1,5 +1,5 @@
 Add the [System.Device.Gpio](https://www.nuget.org/packages/System.Device.Gpio/) package to the project. Use either [.NET CLI](../../core/tools/dotnet-package-add.md) from the project directory or [Visual Studio](/nuget/consume-packages/install-use-packages-visual-studio).
 
 ```dotnetcli
-dotnet add package System.Device.Gpio --version 3.2.0-*
+dotnet add package System.Device.Gpio --version 4.0.1
 ```

--- a/docs/iot/includes/tutorial-add-gpio-package.md
+++ b/docs/iot/includes/tutorial-add-gpio-package.md
@@ -1,5 +1,5 @@
 Add the [System.Device.Gpio](https://www.nuget.org/packages/System.Device.Gpio/) package to the project. Use either [.NET CLI](../../core/tools/dotnet-package-add.md) from the project directory or [Visual Studio](/nuget/consume-packages/install-use-packages-visual-studio).
 
 ```dotnetcli
-dotnet add package System.Device.Gpio --version 4.0.1
+dotnet package add System.Device.Gpio --version 4.0.1
 ```

--- a/docs/iot/includes/tutorial-add-iot-package.md
+++ b/docs/iot/includes/tutorial-add-iot-package.md
@@ -1,5 +1,5 @@
 Add the [Iot.Device.Bindings](https://www.nuget.org/packages/Iot.Device.Bindings/) package to the project. Use either [.NET CLI](../../core/tools/dotnet-package-add.md) from the project directory or [Visual Studio](/nuget/consume-packages/install-use-packages-visual-studio).
 
 ```dotnetcli
-dotnet add package Iot.Device.Bindings --version 4.1.0
+dotnet package add Iot.Device.Bindings --version 4.1.0
 ```

--- a/docs/iot/includes/tutorial-add-iot-package.md
+++ b/docs/iot/includes/tutorial-add-iot-package.md
@@ -1,5 +1,5 @@
 Add the [Iot.Device.Bindings](https://www.nuget.org/packages/Iot.Device.Bindings/) package to the project. Use either [.NET CLI](../../core/tools/dotnet-package-add.md) from the project directory or [Visual Studio](/nuget/consume-packages/install-use-packages-visual-studio).
 
 ```dotnetcli
-dotnet add package Iot.Device.Bindings --version 3.2.0-*
+dotnet add package Iot.Device.Bindings --version 4.1.0
 ```

--- a/docs/iot/includes/tutorial-prereq-dotnet.md
+++ b/docs/iot/includes/tutorial-prereq-dotnet.md
@@ -1,1 +1,1 @@
-[.NET SDK](https://dotnet.microsoft.com/download) 8 or later
+[.NET SDK](https://dotnet.microsoft.com/download) 10 or later

--- a/docs/iot/index.yml
+++ b/docs/iot/index.yml
@@ -10,7 +10,7 @@ metadata:
   ms.topic: landing-page
   ms.collection: collection
   author: camsoper
-  ms.date: 07/31/2024
+  ms.date: 03/07/2026
 
 # linkListType: architecture | concept | deploy | download | get-started | how-to-guide | learn | overview | quickstart | reference | tutorial | video | whats-new
 

--- a/docs/iot/intro.md
+++ b/docs/iot/intro.md
@@ -2,7 +2,7 @@
 title: Develop apps for IoT devices with the .NET IoT Libraries
 description: Learn how .NET can be used to build applications for IoT devices and scenarios.
 author: camsoper
-ms.date: 07/31/2024
+ms.date: 03/07/2026
 ms.topic: overview
 ---
 

--- a/docs/iot/quickstarts/sensehat.md
+++ b/docs/iot/quickstarts/sensehat.md
@@ -2,7 +2,7 @@
 title: Quickstart - Use .NET to drive a Raspberry Pi Sense HAT
 description: Get started with .NET IoT Libraries in 5 minutes using a Sense HAT, an add-on board for Raspberry Pi.
 author: camsoper
-ms.date: 07/31/2024
+ms.date: 03/07/2026
 ms.topic: quickstart
 ---
 

--- a/docs/iot/tutorials/adc.md
+++ b/docs/iot/tutorials/adc.md
@@ -2,7 +2,7 @@
 title: Read values from an analog-to-digital converter
 description: Learn how to read variable voltage values using an analog-to-digital converter.
 author: camsoper
-ms.date: 07/31/2024
+ms.date: 03/07/2026
 ms.topic: tutorial
 ---
 <!--markdownlint-disable DOCSMD011 -->

--- a/docs/iot/tutorials/blink-led.md
+++ b/docs/iot/tutorials/blink-led.md
@@ -2,7 +2,7 @@
 title: Blink an LED
 description: Learn how to blink an LED with the .NET IoT Libraries.
 author: camsoper
-ms.date: 07/31/2024
+ms.date: 03/07/2026
 ms.topic: tutorial
 ---
 

--- a/docs/iot/tutorials/gpio-input.md
+++ b/docs/iot/tutorials/gpio-input.md
@@ -2,7 +2,7 @@
 title: Use GPIO for binary input
 description: Learn how to use GPIO for binary input with the .NET IoT Libraries.
 author: camsoper
-ms.date: 07/31/2024
+ms.date: 03/07/2026
 ms.topic: tutorial
 ---
 

--- a/docs/iot/tutorials/lcd-display.md
+++ b/docs/iot/tutorials/lcd-display.md
@@ -2,7 +2,7 @@
 title: Display text on an LCD
 description: Learn how to display characters on a liquid crystal display with the .NET IoT Libraries.
 author: camsoper
-ms.date: 07/31/2024
+ms.date: 03/07/2026
 ms.topic: tutorial
 ---
 <!--markdownlint-disable DOCSMD011 -->

--- a/docs/iot/tutorials/temp-sensor.md
+++ b/docs/iot/tutorials/temp-sensor.md
@@ -2,7 +2,7 @@
 title: Read environmental conditions from a sensor
 description: Learn how to read temperature, barometric pressure, and humidity with the .NET IoT Libraries.
 author: camsoper
-ms.date: 07/31/2024
+ms.date: 03/07/2026
 ms.topic: tutorial
 ---
 

--- a/docs/iot/usb.md
+++ b/docs/iot/usb.md
@@ -2,7 +2,7 @@
 title: Use .NET IoT Libraries on Windows, Linux, and macOS computers
 description: Learn how to develop GPIO, I2C, and SPI code with .NET on PCs.
 author: camsoper
-ms.date: 07/31/2024
+ms.date: 03/07/2026
 ms.topic: how-to
 ms.custom: linux-related-content
 ---


### PR DESCRIPTION
## Summary
- Update `ms.date` to `03/07/2026` across all 11 IoT documentation files
- Update .NET SDK prerequisite from 8 to **10**
- Update `System.Device.Gpio` package reference from `3.2.0-*` to **4.0.1**
- Update `Iot.Device.Bindings` package reference from `3.2.0-*` to **4.1.0**
- Change `dotnet-install` script channel from `--channel STS` to `--channel LTS` (.NET 10 is LTS)
- Update example SDK version from `8.0.404` to `10.0.103`
- Remove outdated .NET 7 `linux-arm` debugging warning (.NET 7 is end-of-life)

## Companion PR
Companion assets PR: https://github.com/CamSoper/dotnet-iot-assets/pull/1